### PR TITLE
Option to scan multiple files and directories.

### DIFF
--- a/clamtk-gnome.py
+++ b/clamtk-gnome.py
@@ -13,7 +13,10 @@
 # b) the "Artistic License".
 
 import os
-import pipes
+try:
+    from shlex import quote as cmd_quote
+except ImportError:
+    from pipes import quote as cmd_quote
 
 import locale
 locale.setlocale(locale.LC_ALL, '')
@@ -39,10 +42,9 @@ class OpenTerminalExtension(GObject.GObject, Nautilus.MenuProvider):
             #- get_location returns a GFile
             # https://developer.gnome.org/gio/stable/GFile.html
             # which has the get_path function which returns the absolute path as a string
-            filename = pipes.quote(filename)
+            filename = cmd_quote(filename)
             # - when switching to Python 3 we can use shlex.quote() instead
             allPaths.append (filename)
-        print (' '.join(allPaths))
         os.system('clamtk %s &' % ' '.join(allPaths))
 
     def menu_activate_cb(self, menu, files):


### PR DESCRIPTION
Hey @dave-theunsub. I think I will be bothering you a lot in the next few days =)

These changes allow nautilus (or FILES) to use right-click options on multiple files. These are not enough to solve the issue #3 , because for that we need to also change the clamtk command line behaviour (I have another pull request for this).

I also saw the comment about the python3 compatibility function (shlex.quote) and, since this is very easy, I included in this pull a very simple change to solve that issue.

[]s,
Edênis